### PR TITLE
Implement optimistic UI for preset card buttons

### DIFF
--- a/src/components/PresetSongs.tsx
+++ b/src/components/PresetSongs.tsx
@@ -5,6 +5,7 @@ import { useAuthStore } from '../store/authStore';
 import { useAudioStore } from '../store/audioStore';
 import PresetSongCard from './preset/PresetSongCard';
 import type { PresetType } from '../types';
+import { SongState } from '../services/songStateService';
 
 const PRESETS: {
   type: PresetType;
@@ -47,7 +48,8 @@ const PresetSongs: FC = () => {
     handlePresetClick,
     handlePlay,
     handleVariationChange,
-    currentVariationIndices
+    currentVariationIndices,
+    generatingIntent
   } = usePresetSongs();
 
   // Show component only when we have a logged-in user
@@ -105,6 +107,7 @@ const PresetSongs: FC = () => {
               onGenerateClick={handlePresetClick}
               onVariationChange={handleVariationChange}
               currentVariationIndex={currentVariationIndices[type] ?? 0}
+              initialOptimisticState={generatingIntent[type] ? SongState.GENERATING : null}
             />
           );
         })}


### PR DESCRIPTION
## Changes

This PR implements the optimistic UI pattern for preset card buttons to improve perceived responsiveness and fixes a UI flicker issue.

**Initial Implementation (Optimistic UI):**

- Added local optimistic state management (`optimisticSongState`) in the `PresetSongCard` component.
- Immediately update UI to "Generating..." state when a user clicks Generate or Retry.
- Properly handle and revert UI state if the API call fails before a `task_id` is assigned.
- Added documentation comment explaining the optimistic UI pattern.

**Issue Encountered (UI Flicker):**

- After the initial optimistic update to "Generating...", the UI would briefly flicker back to "Generate" (or the previous state) and then to "Generating..." again.
- **Cause:** When a new song generation is initiated, a new song object is created in the `songStore`. This often changes the `key` prop of the `PresetSongCard` in the `PresetSongs` list (as the key includes `songForType?.id`). React then unmounts the old card instance (with its local optimistic state) and mounts a new one, which would re-initialize its optimistic state to `null` before the actual song state (now `GENERATING` from the store) was reflected.

**Fix for UI Flicker:**

- **Lifted Optimistic Intent:** The primary intent to show an optimistic "Generating..." state is now managed in the `usePresetSongs` hook using a `generatingIntent` state variable (a map of `PresetType` to boolean).
- **Propagating Intent:** This `generatingIntent` is passed down from `PresetSongs` to `PresetSongCard` as an `initialOptimisticState` prop.
- **Initializing New Instances:** When a `PresetSongCard` (potentially a new instance due to a key change) mounts, it now initializes its local `optimisticSongState` using this `initialOptimisticState` prop. This ensures new instances correctly reflect an ongoing optimistic generation.
- **Clearing Intent:** Logic in `usePresetSongs` clears the `generatingIntent` for a preset type once the actual song state (from `songStore`) for that preset becomes `GENERATING` (with a `task_id`), `READY`, or `FAILED`.
- The local `optimisticSongState` in `PresetSongCard` is still used for the immediate UI change upon click and is cleared once the actual song state catches up or if the parent-provided `initialOptimisticState` is cleared.

## Benefits

- Improved perceived performance: users get immediate visual feedback.
- Eliminated the delay and the UI flicker, providing a smooth and responsive experience.
- Robust error handling for reverting optimistic states.

## Testing

- Click "Generate" on a preset card: it should immediately and smoothly transition to the "Generating..." state without any flicker back to "Generate".
- Click "Retry" on a failed preset card: it should immediately and smoothly transition to the "Generating..." state.
- If API calls fail before `task_id` assignment, the UI should revert to the previous state ("Generate" or "Retry").
- Ensure that even with new song object creation and potential card remounts, the "Generating..." state persists correctly until the backend confirms the song's status. 